### PR TITLE
Don’t use Promises

### DIFF
--- a/lib/cucumber/sequential_test_case_executor.js
+++ b/lib/cucumber/sequential_test_case_executor.js
@@ -1,12 +1,22 @@
 module.exports = function SequentialTestCaseExecutor(testCases) {
   this.execute = function (eventEmitter) {
+    var all_passed = true;
+    for (var i=0 ; i<testCases.length ; i++) {
+      var testCase = testCases[i];
+      var passed = testCase.execute(eventEmitter);
+      all_passed = all_passed && passed;
+    }
+    return all_passed;
+
     // This is essentially a for loop. If you think it looks weird it's
     // because we're using JavaScript promises, which is a mechanism
     // for running asynchronous code.
-    return testCases.reduce(function (promise, testCase) {
-      return promise.then(function () {
-        return testCase.execute(eventEmitter)
-      });
-    }, Promise.resolve());
+    //
+    // return testCases.reduce(function (promise, testCase) {
+    //   return promise.then(function () {
+    //     return testCase.execute(eventEmitter)
+    //   });
+    // }, Promise.resolve());
+
   };
 };

--- a/lib/cucumber/test_case.js
+++ b/lib/cucumber/test_case.js
@@ -7,24 +7,32 @@ module.exports = function TestCase(pickle, testSteps) {
       pickleSteps: pickle.steps
     });
     var world = {};
-
-    return runTestStepsInSequence(testSteps, eventEmitter, world)
-      .then(function () {
-        eventEmitter.emit('scenario-finished', {
-          path: pickle.path,
-          location: location
-        });
-      });
-  };
+    runTestStepsInSequence(testSteps, eventEmitter, world);
+    eventEmitter.emit('scenario-finished', {
+      path: pickle.path,
+      location: location
+      }
+    );
+  }
 
   function runTestStepsInSequence(testSteps, eventEmitter, world) {
+    var all_passed = true;
+    for (var i=0 ; i<testSteps.length; i++) {
+      var testStep = testSteps[i];
+      var run = all_passed;
+      var passed = testStep.execute(world, eventEmitter, run);
+      all_passed = all_passed && passed;
+    }
+    return all_passed
+
     // This is essentially a for loop. If you think it looks weird it's
     // because we're using JavaScript promises, which is a mechanism
     // for running asynchronous code.
-    return testSteps.reduce(function (promise, testStep) {
-      return promise.then(function (run) {
-        return testStep.execute(world, eventEmitter, run)
-      })
-    }, Promise.resolve(true));
+    // return testSteps.reduce(function (promise, testStep) {
+    //   return promise.then(function (run) {
+    //     return testStep.execute(world, eventEmitter, run)
+    //   })
+    // }, Promise.resolve(true));
+
   }
 };

--- a/lib/cucumber/test_step.js
+++ b/lib/cucumber/test_step.js
@@ -1,48 +1,51 @@
 module.exports = function TestStep(gherkinLocations, matchedArguments, bodyFn, bodyLocation) {
-  this.execute = function (world, eventEmitter, run) {
-    eventEmitter.emit('step-started', {
-      status: 'unknown',
-      gherkinLocation: gherkinLocations[gherkinLocations.length - 1],
-      bodyLocation: bodyLocation,
-      matchedArguments: matchedArguments
-    });
 
-    // We're returning a promise of a boolean here, because JavaScript.
-    // Most languages should simply return a boolean and forget about
-    // the promise stuff - simpler!
-    return new Promise(function (resolve) {
-      if (!bodyFn) {
-        resolve({status: 'undefined'});
-      } else if (!run) {
-        resolve({status: 'skipped'});
-      } else {
-        var matchedArgumentValues = matchedArguments.map(function (arg) {
-          return arg.value
-        });
-        try {
-          // Execute the step definition body
-          var promise = bodyFn.apply(world, matchedArgumentValues);
+  // this object tracks the execution status as it goes
+  var data = {
+    status:           'unknown',
+    gherkinLocation:  gherkinLocations[gherkinLocations.length - 1],
+    bodyLocation:     bodyLocation,
+    matchedArguments: matchedArguments
+  }
 
-          if (promise && typeof(promise.then) === 'function') {
-            // ok, it's a promise
-            promise.then(function () {
-              resolve({status: 'passed'});
-            }).catch(function (err) {
-              resolve({status: 'failed', error: err});
-            })
-          } else {
-            resolve({status: 'passed'});
-          }
-        } catch (err) {
-          resolve({status: 'failed', error: err});
-        }
-      }
-    }).then(function (event) {
-        event.gherkinLocation = gherkinLocations[gherkinLocations.length - 1];
-        event.bodyLocation = bodyLocation;
-        event.matchedArguments = matchedArguments;
-        eventEmitter.emit('step-finished', event);
-        return event.status === 'passed';
-      });
+  //  handles execution details
+  var _execute = function (world, data) {
+    var matchedArgumentValues = matchedArguments.map(
+      function (arg) {return arg.value}
+    );
+    try {
+      // Execute the step definition body
+      result = bodyFn.apply(world, matchedArgumentValues);
+      data.status = 'passed';
+    } catch (err) {
+      data.status = 'failed';
+      data.error = err;
+    } finally {
+      return data;
+    }
+  }
+
+  // main execution logic
+  //
+  //  Overview:
+  //    1. startup
+  //    2. execution
+  //    3. completion
+  this.execute = function(world, eventEmitter, run) {
+    // 1. startup
+    eventEmitter.emit('step-started', data);
+
+    // 2. execution
+    if (!bodyFn) {
+      data.status = 'undefined';
+    } else if (!run) {
+      data.status = 'skipped';
+    } else {
+      data = _execute(world, data);
+    }
+
+    // 3. completion
+    eventEmitter.emit('step-finished', data);
+    return data.status === 'passed';
   }
 };

--- a/test/cucumber/glue_test.js
+++ b/test/cucumber/glue_test.js
@@ -20,7 +20,7 @@ describe("Glue", function () {
             return {
               execute: function () {
                 executed = true;
-                return Promise.resolve();
+                return true;
               }
             };
           }
@@ -31,9 +31,8 @@ describe("Glue", function () {
       var testCase = glue.createTestCase(pickle);
 
       assert(!executed);
-      return testCase.execute(new EventEmitter()).then(function () {
-        assert(executed);
-      });
+      testCase.execute(new EventEmitter());
+      assert(executed);
     });
 
     it("creates an undefined step when no stepdefs match", function () {
@@ -53,10 +52,8 @@ describe("Glue", function () {
         assert.equal(step.status, 'undefined');
         assert.deepEqual(step.gherkinLocation, {path: 'features/hello.feature', line: 3, column: 11});
       });
-      return testCase.execute(eventEmitter)
-        .then(function () {
-          assert.ok(finished);
-        });
+      testCase.execute(eventEmitter);
+      assert(finished);
     });
 
     it("throws an exception when two stepdefs match", function () {
@@ -91,7 +88,7 @@ describe("Glue", function () {
             return {
               execute: function () {
                 result.push('step');
-                return Promise.resolve();
+                return true;
               }
             };
           }
@@ -104,8 +101,8 @@ describe("Glue", function () {
           createTestStep: function (pickle) {
             return {
               execute: function () {
-                result.push('before')
-                return Promise.resolve();
+                result.push('before');
+                return;
               }
             };
           }
@@ -116,7 +113,7 @@ describe("Glue", function () {
             return {
               execute: function () {
                 result.push('after');
-                return Promise.resolve();
+                return;
               }
             };
           }
@@ -127,9 +124,8 @@ describe("Glue", function () {
       var testCase = glue.createTestCase(pickle);
 
       assert.deepEqual(result, []);
-      return testCase.execute(new EventEmitter()).then(function () {
-        assert.deepEqual(result, ['before', 'step', 'after']);
-      });
+      testCase.execute(new EventEmitter());
+      assert.deepEqual(result, ['before', 'step', 'after']);
     });
   });
 });

--- a/test/cucumber/sequential_test_case_executor_test.js
+++ b/test/cucumber/sequential_test_case_executor_test.js
@@ -9,21 +9,17 @@ describe("Runtime", function () {
       var tc1 = {
         execute: function (eventEmitter) {
           order.push(1);
-          return Promise.resolve();
         }
       };
       var tc2 = {
         execute: function (eventEmitter) {
           order.push(2);
-          return Promise.resolve();
         }
       };
 
       var runtime = new SequentialTestCaseExecutor([tc1, tc2]);
-      return runtime.execute(new EventEmitter())
-        .then(function () {
-          assert.deepEqual(order, [1, 2]);
-        });
+      runtime.execute(new EventEmitter())
+      assert.deepEqual(order, [1, 2]);
     });
   });
 });

--- a/test/cucumber/test_case_test.js
+++ b/test/cucumber/test_case_test.js
@@ -10,53 +10,51 @@ describe("TestCase", function () {
         path: 'features/test.feature',
         locations: []
       };
-      var testCase = new TestCase(pickle, [
+      var testSteps = [
         {
           execute: function (world, eventEmitter, run) {
-            return Promise.resolve(true);
+            return true;
           }
         },
         {
           execute: function (world, eventEmitter, run) {
             done = true;
-            assert(run);
-            return Promise.resolve(true);
+            assert(run === true);
+            return true;
           }
         }
-      ]);
+      ];
+      var testCase = new TestCase(pickle, testSteps);
 
-      return testCase.execute(new EventEmitter())
-        .then(function () {
-          assert(done);
-        });
+      testCase.execute(new EventEmitter());
+      assert(done === true);
     });
 
-    it("uses the same this object across steps", function () {
+    it("uses the same 'this' object across steps", function () {
       var done = false;
       var pickle = {
         path: 'features/test.feature',
         locations: []
       };
-      var testCase = new TestCase(pickle, [
+      var testSteps = [
         {
           execute: function (world, eventEmitter, run) {
             world.bingo = 'yes';
-            return Promise.resolve(true);
+            return true;
           }
         },
         {
           execute: function (world, eventEmitter, run) {
             done = true;
             assert.equal(world.bingo, 'yes');
-            return Promise.resolve(true);
+            return true;
           }
         }
-      ]);
+      ];
+      var testCase = new TestCase(pickle, testSteps);
 
-      return testCase.execute(new EventEmitter())
-        .then(function () {
-          assert(done);
-        });
+      testCase.execute(new EventEmitter());
+      assert(done === true);
     });
 
     it("tells next step to not run when previous one failed", function () {
@@ -65,25 +63,24 @@ describe("TestCase", function () {
         path: 'features/test.feature',
         locations: []
       };
-      var testCase = new TestCase(pickle, [
+      var testSteps = [
         {
           execute: function (world, eventEmitter, run) {
-            return Promise.resolve(false);
+            return false;
           }
         },
         {
           execute: function (world, eventEmitter, run) {
             done = true;
             assert(!run);
-            return Promise.resolve(false);
+            return false;
           }
         }
-      ]);
+      ];
+      var testCase = new TestCase(pickle, testSteps);
 
-      return testCase.execute(new EventEmitter())
-        .then(function () {
-          assert(done);
-        });
+      testCase.execute(new EventEmitter());
+      assert(done === true);
     });
   });
 });

--- a/test/cucumber/test_step_test.js
+++ b/test/cucumber/test_step_test.js
@@ -10,34 +10,26 @@ describe("TestStep", function () {
       });
 
       var eventEmitter = new EventEmitter();
-      var step;
       eventEmitter.on('step-started', function (_step) {
-        step = _step;
+        assert.equal(_step.status, 'unknown');
       });
 
       var world = {};
       testStep.execute(world, eventEmitter, true);
-      assert.equal(step.status, 'unknown');
     });
 
-    it("fires an event with status=failed when returning a rejected promise", function () {
+    it("fires an event with status=failed when a test does not pass", function () {
       var locations = [];
       var testStep = new TestStep(locations, [], function () {
-        return Promise.reject(Error("sad trombone"));
+        throw Error("sad trombone");
       });
 
       var eventEmitter = new EventEmitter();
-      var step;
       eventEmitter.on('step-finished', function (_step) {
-        step = _step;
+        assert.equal(_step.status, 'failed')
       });
-
       var world = {};
-      return testStep.execute(world, eventEmitter, true)
-        .then(function (run) {
-          assert(!run);
-          assert.equal(step.status, 'failed');
-        });
+      testStep.execute(world, eventEmitter, true);
     });
 
     it("fires an event with status=failed when an exception is thrown", function () {
@@ -47,17 +39,12 @@ describe("TestStep", function () {
       });
 
       var eventEmitter = new EventEmitter();
-      var step;
       eventEmitter.on('step-finished', function (_step) {
-        step = _step;
+        assert.equal(_step.status, 'failed');
       });
 
       var world = {};
-      return testStep.execute(world, eventEmitter, true)
-        .then(function (run) {
-          assert(!run);
-          assert.equal(step.status, 'failed');
-        });
+      return testStep.execute(world, eventEmitter, true);
     });
 
     it("fires an event with status=skipped when the run parameter is false", function () {
@@ -67,56 +54,33 @@ describe("TestStep", function () {
       });
 
       var eventEmitter = new EventEmitter();
-      var step;
       eventEmitter.on('step-finished', function (_step) {
-        step = _step;
+        assert.equal(_step.status, 'skipped');
       });
 
       var world = {};
-      return testStep.execute(world, eventEmitter, false)
-        .then(function (run) {
-          assert(!run);
-          assert.equal(step.status, 'skipped');
-        });
+      return testStep.execute(world, eventEmitter, false);
     });
 
     it("fires an event with status=passed when no exception is thrown", function () {
       var locations = [];
       var testStep = new TestStep(locations, [], function () {
+        var a = 0;
+        return a
       });
 
       var eventEmitter = new EventEmitter();
-      var step;
       eventEmitter.on('step-finished', function (_step) {
-        step = _step;
+        try { assert.equal(_step.status, 'passed'); }
+        catch (err) {
+          console.error(err)
+          console.error('step was:\n')
+          console.error(_step)
+        }
       });
 
       var world = {};
-      return testStep.execute(world, eventEmitter, true)
-        .then(function (run) {
-          assert(run);
-          assert.equal(step.status, 'passed');
-        });
-    });
-
-    it("fires an event with status=passed when returning a resolved promise", function () {
-      var locations = [];
-      var testStep = new TestStep(locations, [], function () {
-        return Promise.resolve();
-      });
-
-      var eventEmitter = new EventEmitter();
-      var step;
-      eventEmitter.on('step-finished', function (_step) {
-        step = _step;
-      });
-
-      var world = {};
-      return testStep.execute(world, eventEmitter, true)
-        .then(function (run) {
-          assert(run);
-          assert.equal(step.status, 'passed');
-        });
+      testStep.execute(world, eventEmitter, true);
     });
 
     it("fires an event with status=undefined when no body exists", function () {
@@ -124,17 +88,13 @@ describe("TestStep", function () {
       var testStep = new TestStep(locations, [], null);
 
       var eventEmitter = new EventEmitter();
-      var step;
       eventEmitter.on('step-finished', function (_step) {
         step = _step;
+        assert.equal(step.status, 'undefined', true);
       });
 
       var world = {};
-      return testStep.execute(world, eventEmitter, true)
-        .then(function (run) {
-          assert(!run);
-          assert.equal(step.status, 'undefined', true);
-        });
+      testStep.execute(world, eventEmitter, true);
     });
 
     it("passes argument values to body function", function () {
@@ -148,10 +108,8 @@ describe("TestStep", function () {
 
       var eventEmitter = new EventEmitter();
       var world = {};
-      return testStep.execute(world, eventEmitter, true)
-        .then(function (run) {
-          assert.equal(arg, 'hello');
-        });
+      testStep.execute(world, eventEmitter, true);
+      assert.equal(arg, 'hello');
     });
   });
 });


### PR DESCRIPTION
In the spirit of Issue #8 (Don’t use EventEmitter), this PR removes Promises from microcuke. 

Reasoning:

- Although Promises are not JS-specific, they are an **async** idea.  
- Fewer people are familiar with async programming than normal/sync programming.
- Asynchronous programming styles vary *wildly* across libraries and languages.
- A previous comment in the source said something to the effect of, “we’re using Promises, because JavaScript.  You should just return a boolean, because it’s simpler!”  
    - If microcuke is supposed to a minimalist, simple-as-possible reference implementation, Promises introduce a barrier to the person reading microcuke in order to write their own implementation.  (Code that would be a simple for-loop becomes a nested group of promises and anonymous function calls; a simple return value (boolean) is replaced by a more complex block of code; etc.)

The benefits of this have a lot of overlap with those of Issue #8 (removing EventEmitter):

- People who are unfamiliar with Promises or async programming will not be put off by unfamiliarity with Promises
- Easier to read and understand (even for people who *do* understand Promises)
- Easier to port to other languages
- When porting to other languages, someone can use their *preferred* async tools/constructs in their implementation 
- We can add comments like, “Your implementation could use async here if desired” to encourage performance for implementations, while microcuke itself remains simple and straightforward to read and grok

